### PR TITLE
Add customizable sleep timer

### DIFF
--- a/screens/RadioPlayer.js
+++ b/screens/RadioPlayer.js
@@ -1,6 +1,6 @@
 // screens/RadioPlayer.js
-import React, { useEffect } from 'react';
-import { View, Image, TouchableOpacity, StyleSheet, useColorScheme, Alert } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Image, TouchableOpacity, StyleSheet, useColorScheme, Alert, Modal, TextInput, Text } from 'react-native';
 import Slider from '@react-native-community/slider';
 import { Ionicons } from '@expo/vector-icons';
 import { usePlayer } from '../context/PlayerContext';
@@ -10,6 +10,8 @@ export default function RadioPlayer({ route, navigation }) {
   const { radio, isPlaying, play, toggle, volume, setVolume, setSleepTimer } = usePlayer();
   const scheme = useColorScheme();
   const styles = getStyles(scheme === 'dark');
+  const [timerModal, setTimerModal] = useState(false);
+  const [customMinutes, setCustomMinutes] = useState('');
 
   useEffect(() => {
     navigation.setOptions({ title: routeRadio.name });
@@ -24,6 +26,7 @@ export default function RadioPlayer({ route, navigation }) {
       { text: '5m', onPress: () => setSleepTimer(300) },
       { text: '10m', onPress: () => setSleepTimer(600) },
       { text: '30m', onPress: () => setSleepTimer(1800) },
+      { text: 'Personalizado', onPress: () => setTimerModal(true) },
     ]);
   };
 
@@ -31,9 +34,15 @@ export default function RadioPlayer({ route, navigation }) {
     <View style={styles.container}>
       <Image source={{ uri: routeRadio.logo }} style={styles.logo} />
 
-      <TouchableOpacity onPress={toggle} style={styles.playButton}>
-        <Ionicons name={isPlaying ? 'pause' : 'play'} size={48} color="white" />
-      </TouchableOpacity>
+      <View style={styles.controlsRow}>
+        <TouchableOpacity onPress={toggle} style={styles.playButton}>
+          <Ionicons name={isPlaying ? 'pause' : 'play'} size={48} color="white" />
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={askTimer} style={styles.timerButton}>
+          <Ionicons name="time" size={28} color="#fff" />
+        </TouchableOpacity>
+      </View>
 
       <Slider
         style={styles.slider}
@@ -44,9 +53,50 @@ export default function RadioPlayer({ route, navigation }) {
         minimumTrackTintColor="#4caf50"
       />
 
-      <TouchableOpacity onPress={askTimer} style={styles.timerButton}>
-        <Ionicons name="time" size={28} color="#fff" />
-      </TouchableOpacity>
+      <Modal
+        visible={timerModal}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setTimerModal(false)}
+      >
+        <View style={styles.modalBackdrop}>
+          <View style={styles.modalContent}>
+            <Text style={styles.modalTitle}>Minutos até parar</Text>
+            <TextInput
+              style={styles.modalInput}
+              keyboardType="numeric"
+              value={customMinutes}
+              onChangeText={setCustomMinutes}
+              placeholder="ex: 15"
+              placeholderTextColor="#999"
+            />
+            <View style={styles.modalButtons}>
+              <TouchableOpacity
+                onPress={() => {
+                  setTimerModal(false);
+                  setCustomMinutes('');
+                }}
+                style={styles.modalButton}
+              >
+                <Text style={styles.modalButtonText}>Cancelar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={() => {
+                  const mins = parseInt(customMinutes, 10);
+                  if (!isNaN(mins) && mins > 0) {
+                    setSleepTimer(mins * 60);
+                    setTimerModal(false);
+                    setCustomMinutes('');
+                  }
+                }}
+                style={styles.modalButton}
+              >
+                <Text style={styles.modalButtonText}>OK</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -72,14 +122,42 @@ const getStyles = (dark) => StyleSheet.create({
     borderRadius: 100,
     alignItems: 'center',
     justifyContent: 'center',
-    marginBottom: 20,
   },
   slider: { width: '80%', marginTop: 20 },
   timerButton: {
-    marginTop: 30,
+    marginLeft: 20,
     backgroundColor: '#4caf50',
     padding: 12,
     borderRadius: 50,
   },
+  controlsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 20,
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  modalContent: {
+    backgroundColor: dark ? '#222' : '#fff',
+    padding: 20,
+    borderRadius: 12,
+    width: '80%',
+  },
+  modalTitle: { fontSize: 16, marginBottom: 12, color: dark ? '#fff' : '#000' },
+  modalInput: {
+    backgroundColor: dark ? '#333' : '#f4f4f4',
+    borderRadius: 8,
+    padding: 10,
+    color: dark ? '#fff' : '#000',
+    marginBottom: 20,
+  },
+  modalButtons: { flexDirection: 'row', justifyContent: 'flex-end' },
+  modalButton: { marginLeft: 16 },
+  modalButtonText: { color: '#4caf50', fontSize: 16 },
 });
 


### PR DESCRIPTION
## Summary
- add modal for custom sleep timer duration
- place timer control next to play button

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6858692937408333b012f1a25d80c4f7